### PR TITLE
Refactored x() to x everywhere

### DIFF
--- a/geometry/aabb.h
+++ b/geometry/aabb.h
@@ -19,13 +19,13 @@ public:
 };
 
 inline aabb surrounding_box(aabb box0, aabb box1) {
-    point3 small(fmin(box0.min().x(), box1.min().x()),
-                 fmin(box0.min().y(), box1.min().y()),
-                 fmin(box0.min().z(), box1.min().z()));
+    point3 small(fmin(box0.min().x, box1.min().x),
+                 fmin(box0.min().y, box1.min().y),
+                 fmin(box0.min().z, box1.min().z));
 
-    point3 big(fmax(box0.max().x(), box1.max().x()),
-               fmax(box0.max().y(), box1.max().y()),
-               fmax(box0.max().z(), box1.max().z()));
+    point3 big(fmax(box0.max().x, box1.max().x),
+               fmax(box0.max().y, box1.max().y),
+               fmax(box0.max().z, box1.max().z));
     return aabb(small, big);
 }
 

--- a/geometry/quad.h
+++ b/geometry/quad.h
@@ -113,13 +113,13 @@ bool quad::hit(const ray& r, double t_min, double t_max, hit_record& rec) const 
 bool quad::bounding_box(aabb &output_box) const {
     point3 min, max;
     min = point3(
-        dmin4(v0.x(), v1.x(), v2.x(), v3.x()),
-        dmin4(v0.y(), v1.y(), v2.y(), v3.y()),
-        dmin4(v0.z(), v1.z(), v2.z(), v3.z()));
+        dmin4(v0.x, v1.x, v2.x, v3.x),
+        dmin4(v0.y, v1.y, v2.y, v3.y),
+        dmin4(v0.z, v1.z, v2.z, v3.z));
     max = point3(
-        dmax4(v0.x(), v1.x(), v2.x(), v3.x()),
-        dmax4(v0.y(), v1.y(), v2.y(), v3.y()),
-        dmax4(v0.z(), v1.z(), v2.z(), v3.z()));
+        dmax4(v0.x, v1.x, v2.x, v3.x),
+        dmax4(v0.y, v1.y, v2.y, v3.y),
+        dmax4(v0.z, v1.z, v2.z, v3.z));
     output_box = aabb(min, max);
     return true;
 }

--- a/geometry/rectangle.h
+++ b/geometry/rectangle.h
@@ -22,11 +22,11 @@ class xy_rect : public hittable {
 };
 
 bool xy_rect::hit(const ray& r, double t_min, double t_max, hit_record& rec) const {
-    auto t = (k-r.origin().z()) / r.direction().z();
+    auto t = (k-r.origin().z) / r.direction().z;
     if (t < t_min || t > t_max)
         return false;
-    auto x = r.origin().x() + t*r.direction().x();
-    auto y = r.origin().y() + t*r.direction().y();
+    auto x = r.origin().x + t*r.direction().x;
+    auto y = r.origin().y + t*r.direction().y;
     if (x < x0 || x > x1 || y < y0 || y > y1)
         return false;
     rec.u = (x-x0)/(x1-x0);

--- a/geometry/sphere.h
+++ b/geometry/sphere.h
@@ -22,8 +22,8 @@ class sphere : public hittable{
 
     private:
         static void get_sphere_uv(const point3& p, double& u, double& v) {
-            auto theta = acos(-p.y());
-            auto phi = atan2(-p.z(), p.x()) + PI;
+            auto theta = acos(-p.y);
+            auto phi = atan2(-p.z, p.x) + PI;
 
             u = phi / (2 * PI);
             v = theta / PI;

--- a/geometry/triangle.h
+++ b/geometry/triangle.h
@@ -87,26 +87,26 @@ bool triangle::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
 
     //uv mappng
     
-    double den0 =  (v1.y()-v2.y())*(v0.x()-v2.x()) + (v2.x()-v1.x())*(v0.y()-v2.y());
+    double den0 =  (v1.y-v2.y)*(v0.x-v2.x) + (v2.x-v1.x)*(v0.y-v2.y);
     // if(den0<=0.00000001){
-    //     rec.u = 0.333*uv0.x() + 0.333*uv1.x() + 0.333*uv2.x();
-    //     rec.v = 0.333*uv0.y() + 0.333*uv1.y() + 0.333*uv2.y();
+    //     rec.u = 0.333*uv0.x + 0.333*uv1.x + 0.333*uv2.x;
+    //     rec.v = 0.333*uv0.y + 0.333*uv1.y + 0.333*uv2.y;
     //     return true;
     // }
-    // rec.u = 0.333*uv0.x() + 0.333*uv1.x() + 0.333*uv2.x();
-    // rec.v = 0.333*uv0.y() + 0.333*uv1.y() + 0.333*uv2.y();
-    double Baryv0 = ((v1.y()-v2.y())*(P.x()-v2.x()) + (v2.x()-v1.x())*(P.y()-v2.y())) /
-                    ((v1.y()-v2.y())*(v0.x()-v2.x()) + (v2.x()-v1.x())*(v0.y()-v2.y()));
-    double Baryv1 = ((v2.y()-v0.y())*(P.x()-v2.x()) + (v0.x()-v2.x())*(P.y()-v2.y())) /
-                     ((v1.y()-v2.y())*(v0.x()-v2.x()) + (v2.x()-v1.x())*(v0.y()-v2.y()));
+    // rec.u = 0.333*uv0.x + 0.333*uv1.x + 0.333*uv2.x;
+    // rec.v = 0.333*uv0.y + 0.333*uv1.y + 0.333*uv2.y;
+    double Baryv0 = ((v1.y-v2.y)*(P.x-v2.x) + (v2.x-v1.x)*(P.y-v2.y)) /
+                    ((v1.y-v2.y)*(v0.x-v2.x) + (v2.x-v1.x)*(v0.y-v2.y));
+    double Baryv1 = ((v2.y-v0.y)*(P.x-v2.x) + (v0.x-v2.x)*(P.y-v2.y)) /
+                     ((v1.y-v2.y)*(v0.x-v2.x) + (v2.x-v1.x)*(v0.y-v2.y));
     double Baryv2 = 1 - Baryv0 - Baryv1;
-    rec.u = Baryv0*uv0.x() + Baryv1*uv1.x() + Baryv2*uv2.x();
-    rec.v = Baryv0*uv0.y() + Baryv1*uv1.y() + Baryv2*uv2.y();
-    // std::cerr << "v0 = " << v0.x() << " " << v0.y() << " " << v0.z() << std::endl;
-    // std::cerr << "v1 = " << v1.x() << " " << v1.y() << " " << v1.z() << std::endl;
-    // std::cerr << "v2 = " << v2.x() << " " << v2.y() << " " << v2.z() << std::endl;
-    // std::cerr << "P = " << P.x() << " " << P.y() << " " << P.z() << std::endl;
-    // std::cerr << "Numerator = " << ((v1.y()-v2.y())*(P.x()-v2.x()) + (v2.x()-v1.x())*(P.y()-v2.y())) << std::endl;
+    rec.u = Baryv0*uv0.x + Baryv1*uv1.x + Baryv2*uv2.x;
+    rec.v = Baryv0*uv0.y + Baryv1*uv1.y + Baryv2*uv2.y;
+    // std::cerr << "v0 = " << v0.x << " " << v0.y << " " << v0.z << std::endl;
+    // std::cerr << "v1 = " << v1.x << " " << v1.y << " " << v1.z << std::endl;
+    // std::cerr << "v2 = " << v2.x << " " << v2.y << " " << v2.z << std::endl;
+    // std::cerr << "P = " << P.x << " " << P.y << " " << P.z << std::endl;
+    // std::cerr << "Numerator = " << ((v1.y-v2.y)*(P.x-v2.x) + (v2.x-v1.x)*(P.y-v2.y)) << std::endl;
     // std::cerr << "denominator = " << den0 << std::endl;
     // std::cerr << Baryv0 << " " << Baryv1 << " " << Baryv2 << " " << rec.u << " " << rec.v << std::endl;
     
@@ -117,13 +117,13 @@ bool triangle::hit(const ray& r, double t_min, double t_max, hit_record& rec) co
 bool triangle::bounding_box(aabb& output_box) const {
     point3 min, max;
     min = point3(
-        dmin3(v0.x(), v1.x(), v2.x()),
-        dmin3(v0.y(), v1.y(), v2.y()),
-        dmin3(v0.z(), v1.z(), v2.z()));
+        dmin3(v0.x, v1.x, v2.x),
+        dmin3(v0.y, v1.y, v2.y),
+        dmin3(v0.z, v1.z, v2.z));
     max = point3(
-        dmax3(v0.x(), v1.x(), v2.x()),
-        dmax3(v0.y(), v1.y(), v2.y()),
-        dmax3(v0.z(), v1.z(), v2.z()));
+        dmax3(v0.x, v1.x, v2.x),
+        dmax3(v0.y, v1.y, v2.y),
+        dmax3(v0.z, v1.z, v2.z));
     output_box = aabb(min, max);
     return true;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -159,9 +159,9 @@ int main(int argc, char** argv)
 
         for (int j = 0; j < img_height; ++j) {
             for (int i = 0; i < img_width; ++i) {
-                uint8_t red   = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].x(), 0.0, 0.999));
-                uint8_t green = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].y(), 0.0, 0.999));
-                uint8_t blue  = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].y(), 0.0, 0.999));
+                uint8_t red   = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].x, 0.0, 0.999));
+                uint8_t green = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].y, 0.0, 0.999));
+                uint8_t blue  = static_cast<uint8_t>(256.0 * clamp(a[i*img_height+j].y, 0.0, 0.999));
                 j = img_height - j - 1;
                 pixels[j * img_width + i] = SDL_MapRGB(pixelFormat, red, green, blue);
             }

--- a/material/color.h
+++ b/material/color.h
@@ -6,9 +6,9 @@
 #include<iostream>
 
 void writeColor(std::ostream &out, color pixel_color, int samples_per_pixel){
-    auto r = pixel_color.x();
-    auto g = pixel_color.y();
-    auto b = pixel_color.z();
+    auto r = pixel_color.x;
+    auto g = pixel_color.y;
+    auto b = pixel_color.z;
     
     // //Divide the color by number of samples and gamma correct for gamma 2.0
     auto scale = 1.0/samples_per_pixel;

--- a/material/perlin.h
+++ b/material/perlin.h
@@ -29,13 +29,13 @@ public:
 
     double noise(const point3& p) const {
 
-        auto u = p.x() - floor(p.x());
-        auto v = p.y() - floor(p.y());
-        auto w = p.z() - floor(p.z());
+        auto u = p.x - floor(p.x);
+        auto v = p.y - floor(p.y);
+        auto w = p.z - floor(p.z);
 
-        auto i = static_cast<int>(floor(p.x()));
-        auto j = static_cast<int>(floor(p.y()));
-        auto k = static_cast<int>(floor(p.z()));
+        auto i = static_cast<int>(floor(p.x));
+        auto j = static_cast<int>(floor(p.y));
+        auto k = static_cast<int>(floor(p.z));
 
         vec3 c[2][2][2];
 

--- a/material/texture.h
+++ b/material/texture.h
@@ -38,7 +38,7 @@ class checker_texture : public texture {
             : even(make_shared<solid_color>(c1)), odd(make_shared<solid_color>(c2)) {}
 
         virtual color value(double u, double v, const point3& p) const override {
-            auto sines = sin(10*p.x()) * sin(10*p.y()) * sin(10*p.z());
+            auto sines = sin(10*p.x) * sin(10*p.y) * sin(10*p.z);
             if (sines < 0)
                 return odd->value(u, v, p);
             return even->value(u, v, p);
@@ -53,7 +53,7 @@ public:
     noise_texture(double sc) : scale(sc) {}
 
     virtual color value(double u, double v, const point3& p) const override {
-        return color(1,1,1) * 0.5 * (1 + sin(scale*p.z() + 10 * noise.turb(scale*p)));
+        return color(1,1,1) * 0.5 * (1 + sin(scale*p.z + 10 * noise.turb(scale*p)));
     }
 
     perlin noise;

--- a/renderer/camera.h
+++ b/renderer/camera.h
@@ -51,7 +51,7 @@ class camera {
 
         ray get_ray(double s, double t) const{
             vec3 rd = lens_radius * random_in_unit_disk();
-            vec3 offset = u*rd.x() + v*rd.y();
+            vec3 offset = u*rd.x + v*rd.y;
             return ray(origin+offset, lower_left_corner+s*horizontal+t*vertical-origin-offset);
         }
 

--- a/renderer/renderer.h
+++ b/renderer/renderer.h
@@ -21,7 +21,7 @@ color rayColor(const ray& r, const hittable& world, int depth){
     }
 
     vec3 unit_direction = unitVector(r.direction());
-    auto t=0.5*(unit_direction.y()+1.0);
+    auto t=0.5*(unit_direction.y+1.0);
     return (1.0-t)*color(1.0,1.0,1.0)+t*color(0.5,0.7,1.0);
 }
 

--- a/renderer/vec3.h
+++ b/renderer/vec3.h
@@ -62,7 +62,13 @@ union vec3
         double x, y, z;
     };
     struct {
-        double r, g, b;
+        double R, G, B;
+    };
+    struct {
+        double u, v, w;
+    };
+    struct {
+        double a, b, c;
     };
 };
 

--- a/renderer/vec3.h
+++ b/renderer/vec3.h
@@ -7,63 +7,63 @@
 #include "rt.h"
 
 //Vector3 Class
-class vec3
+union vec3
 {
-    public:
-        vec3(): p{0,0,0} {}
-        vec3(double p0, double p1, double p2): p{p0,p1,p2} {}
+    vec3(): p{0,0,0} {}
+    vec3(double p0, double p1, double p2): p{p0,p1,p2} {}
 
-        double x() const{return p[0];}
-        double y() const{return p[1];}
-        double z() const{return p[2];}
+    vec3 operator - () const{return vec3(-p[0],-p[1],-p[2]);}
+    double operator [] (int i) const{return p[i];}
+    double& operator [] (int i) {return p[i];}
 
-        vec3 operator - () const{return vec3(-p[0],-p[1],-p[2]);}
-        double operator [] (int i) const{return p[i];}
-        double& operator [] (int i) {return p[i];}
+    vec3& operator += (const vec3 &v){
+        p[0] += v.p[0];
+        p[1] += v.p[1];
+        p[2] += v.p[2];
+        return *this;
+    }
 
-        vec3& operator += (const vec3 &v){
-            p[0] += v.p[0];
-            p[1] += v.p[1];
-            p[2] += v.p[2];
-            return *this;
-        }
+    vec3& operator *= (const double t){
+        p[0] *= t;
+        p[1] *= t;
+        p[2] *= t;
+        return *this;
+        //or, return *this *=t;
+    }
 
-        vec3& operator *= (const double t){
-            p[0] *= t;
-            p[1] *= t;
-            p[2] *= t;
-            return *this;
-            //or, return *this *=t;
-        }
+    vec3& operator /= (const double t){
+        return *this *= 1/t; 
+    }
 
-        vec3& operator /= (const double t){
-            return *this *= 1/t; 
-        }
+    double length() const{
+        return std::sqrt(lengthSquared());
+    }
 
-        double length() const{
-            return std::sqrt(lengthSquared());
-        }
+    double lengthSquared() const{
+        return p[0]*p[0]+p[1]*p[1]+p[2]*p[2];
+    }
 
-        double lengthSquared() const{
-            return p[0]*p[0]+p[1]*p[1]+p[2]*p[2];
-        }
+    inline static vec3 random() {
+        return vec3(random_double(),random_double(),random_double());
+    }
 
-        inline static vec3 random() {
-            return vec3(random_double(),random_double(),random_double());
-        }
+    inline static vec3 random(double min, double max) {
+        return vec3(random_double(min,max), random_double(min,max), random_double(min,max));
+    }
 
-        inline static vec3 random(double min, double max) {
-            return vec3(random_double(min,max), random_double(min,max), random_double(min,max));
-        }
-
-        bool near_zero() const{
-            //returns true if vector is close to zero in all dimensions
-            const auto s = 1e-8;
-            return (fabs(p[0])<s) && (fabs(p[1])<s) && (fabs(p[2])<s);
-        }
+    bool near_zero() const{
+        //returns true if vector is close to zero in all dimensions
+        const auto s = 1e-8;
+        return (fabs(p[0])<s) && (fabs(p[1])<s) && (fabs(p[2])<s);
+    }
     
-    public:
-        double p[3];
+    double p[3];
+    struct {
+        double x, y, z;
+    };
+    struct {
+        double r, g, b;
+    };
 };
 
 //aliases for vec3


### PR DESCRIPTION
Refactored:
`x()` to `x`
`y()` to `y`
`z()` to `z`
Made `vec3` a union.
Also added fields `r`, `g`, `b` that points to the same `x`, `y`, `z` fields.

Compiles properly and produces expected result.